### PR TITLE
Add basic unit tests for PointService

### DIFF
--- a/WebApplication6.Tests/PointServiceTests.cs
+++ b/WebApplication6.Tests/PointServiceTests.cs
@@ -1,0 +1,60 @@
+using GenericRepositoryApp.Data;
+using GenericRepositoryApp.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class PointServiceTests : System.IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly PointService _service;
+
+    public PointServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: System.Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        var unitOfWork = new UnitOfWork(_context);
+        _service = new PointService(unitOfWork);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPointByIdAsync_ReturnsPoint_WhenExists()
+    {
+        var point = new Point { PointX = 1, PointY = 2, Name = "Test" };
+        await _service.AddPointAsync(point);
+
+        var result = await _service.GetPointByIdAsync(point.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal("Test", result!.Name);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task AddPointAsync_PersistsPoint()
+    {
+        var point = new Point { PointX = 3, PointY = 4, Name = "Add" };
+
+        await _service.AddPointAsync(point);
+
+        var exists = await _context.Points.AnyAsync(p => p.Id == point.Id);
+        Assert.True(exists);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DeletePointAsync_RemovesPoint()
+    {
+        var point = new Point { PointX = 5, PointY = 6, Name = "Delete" };
+        await _service.AddPointAsync(point);
+
+        await _service.DeletePointAsync(point.Id);
+
+        var removed = await _context.Points.FindAsync(point.Id);
+        Assert.Null(removed);
+    }
+}

--- a/WebApplication6.Tests/WebApplication6.Tests.csproj
+++ b/WebApplication6.Tests/WebApplication6.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebApplication6\WebApplication6.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebApplication6.sln
+++ b/WebApplication6.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.10.35201.131
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication6", "WebApplication6\WebApplication6.csproj", "{41F55225-4DA8-4E0E-B83C-AD653AD4660E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication6.Tests", "WebApplication6.Tests\WebApplication6.Tests.csproj", "{A49AA561-9714-4080-8629-3B543821A6C8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {41F55225-4DA8-4E0E-B83C-AD653AD4660E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A49AA561-9714-4080-8629-3B543821A6C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A49AA561-9714-4080-8629-3B543821A6C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A49AA561-9714-4080-8629-3B543821A6C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A49AA561-9714-4080-8629-3B543821A6C8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add xUnit test project using EF Core InMemory provider
- test `PointService` methods `GetPointByIdAsync`, `AddPointAsync`, and `DeletePointAsync`
- register new test project in solution

## Testing
- `dotnet test WebApplication6.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f70f399d0832182fb5b3a96a474e4