### PR TITLE
Fix nullability issues in models

### DIFF
--- a/WebApplication6/Data/AppDbContext.cs
+++ b/WebApplication6/Data/AppDbContext.cs
@@ -7,8 +7,8 @@ namespace GenericRepositoryApp.Data
     {
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
-        public DbSet<Point> Points { get; set; }
-        public DbSet<AnotherEntity> AnotherEntities { get; set; }  // Eklenen diğer entity'ler
+        public DbSet<Point> Points { get; set; } = null!;
+        public DbSet<AnotherEntity> AnotherEntities { get; set; } = null!;  // Eklenen diğer entity'ler
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/WebApplication6/Models/AnotherEntity.cs
+++ b/WebApplication6/Models/AnotherEntity.cs
@@ -3,6 +3,6 @@
     public class AnotherEntity
     {
         public int Id { get; set; }
-        public string Description { get; set; }
+        public string Description { get; set; } = null!;
     }
 }

--- a/WebApplication6/Models/Point.cs
+++ b/WebApplication6/Models/Point.cs
@@ -5,6 +5,6 @@
         public int Id { get; set; }
         public double PointX { get; set; }
         public double PointY { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }


### PR DESCRIPTION
## Summary
- initialize string properties to avoid nullability warnings
- initialize EF DbSet properties

## Testing
- `dotnet test WebApplication6/WebApplication6.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f68610f848321b65e099c090f9880